### PR TITLE
Add `once_cell` as a crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+once_cell = "1.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
+pub extern crate once_cell;
+
 #[macro_export]
 macro_rules! defvar {
     { $name:ident: $type:ty = $default:expr, or try $var:ident => $transform:block $(;)? } => {
-        static $name: ::once_cell::sync::Lazy<$type> = ::once_cell::sync::Lazy::new(|| {
+        static $name: $crate::once_cell::sync::Lazy<$type> = $crate::once_cell::sync::Lazy::new(|| {
             match ::std::env::var(stringify!($name)) {
                 Ok($var) => {
                     match $transform {


### PR DESCRIPTION
Adding `once_cell` as a crate dependency and using the `$crate` path scoping prefix removes the need to add `once_cell` as a dependency to the calling crate.